### PR TITLE
Convert to ExtUtils::MakeMaker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ blib
 *.bak
 MANIFEST
 App-CLI-*.tar.gz
+MYMETA.*

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -9,3 +9,4 @@ test*
 shipit
 META.yml
 .*\.bak$
+MYMETA.json

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,21 +1,21 @@
 #!/usr/bin/perl
 
-use inc::Module::Install;
+use strict;
+use warnings;
 
-name		('App-CLI');
-author		('Chia-liang Kao <clkao@clkao.org>');
-# author		('Cornelius <cornelius.howl@gmail.com>');
-abstract_from	('lib/App/CLI.pm');
-license		('perl');
-version_from	('lib/App/CLI.pm');
+use ExtUtils::MakeMaker qw(6.3.1);
 
-requires(
-    'Locale::Maketext::Simple' => 0,
-    'Getopt::Long'             => '2.35',
-    'Pod::Simple::Text'        => 0,
+WriteMakefile(
+    NAME          => "App::CLI",
+    VERSION_FROM  => "lib/App/CLI.pm",
+    ABSTRACT_FROM => "lib/App/CLI.pm",
+    AUTHOR        => ('Chia-liang Kao <clkao@clkao.org>'),
+    LICENSE       => "perl_5",
+    PREREQ_PM     => {
+        'Locale::Maketext::Simple' => 0,
+        'Getopt::Long'             => '2.35',
+        'Pod::Simple::Text'        => 0,
+    },
 );
 
-auto_install();
-
-# WriteAll( sign => 1 );
-WriteAll( );
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
`Module::Install` is deprecated for module building and installation (see http://search.cpan.org/~ether/Module-Install-1.18/lib/Module/Install.pod#WARNING).  This change converts the metadata contained in the original `Makefile.PL` to use `ExtUtils::MakeMaker`, which is in core Perl and hence is still actively supported.