### PR TITLE
Unskip META.yml

### DIFF
--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -7,5 +7,4 @@ MYMETA.yml
 .tar.gz$
 test*
 shipit
-META.yml
 .*\.bak$


### PR DESCRIPTION
The file `META.yml` is required in Perl distributions so that
CPAN-related tools can work more efficiently.  Hence, this file should
not be skipped and should be added the `MANIFEST` and dist tarball the
next time this dist is released.